### PR TITLE
Add Premium role to users upon plan purchase and remove upon cancellation

### DIFF
--- a/api/store/removesubscription.php
+++ b/api/store/removesubscription.php
@@ -94,7 +94,6 @@ if (verifyWebhook($body, $headers)) {
         $conn->query("UPDATE `mythicaldash_users` SET `ram` = '" . mysqli_real_escape_string($conn, $newram) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
         $conn->query("UPDATE `mythicaldash_users` SET `disk` = '" . mysqli_real_escape_string($conn, $newdisk) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
         $conn->query("UPDATE `mythicaldash_users` SET `server_limit` = '" . mysqli_real_escape_string($conn, $newsv) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
-        $conn->close();
     }
 
     if ($row["coins"] == '2') {
@@ -110,7 +109,6 @@ if (verifyWebhook($body, $headers)) {
         $conn->query("UPDATE `mythicaldash_users` SET `ram` = '" . mysqli_real_escape_string($conn, $newram) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
         $conn->query("UPDATE `mythicaldash_users` SET `disk` = '" . mysqli_real_escape_string($conn, $newdisk) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
         $conn->query("UPDATE `mythicaldash_users` SET `server_limit` = '" . mysqli_real_escape_string($conn, $newsv) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
-        $conn->close();
     }
 
     if ($row["coins"] == '3') {
@@ -126,7 +124,6 @@ if (verifyWebhook($body, $headers)) {
         $conn->query("UPDATE `mythicaldash_users` SET `ram` = '" . mysqli_real_escape_string($conn, $newram) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
         $conn->query("UPDATE `mythicaldash_users` SET `disk` = '" . mysqli_real_escape_string($conn, $newdisk) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
         $conn->query("UPDATE `mythicaldash_users` SET `server_limit` = '" . mysqli_real_escape_string($conn, $newsv) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
-        $conn->close();
     }
 
     if ($row["coins"] == '4') {
@@ -142,7 +139,6 @@ if (verifyWebhook($body, $headers)) {
         $conn->query("UPDATE `mythicaldash_users` SET `ram` = '" . mysqli_real_escape_string($conn, $newram) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
         $conn->query("UPDATE `mythicaldash_users` SET `disk` = '" . mysqli_real_escape_string($conn, $newdisk) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
         $conn->query("UPDATE `mythicaldash_users` SET `server_limit` = '" . mysqli_real_escape_string($conn, $newsv) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
-        $conn->close();
     }
 
     if ($row["coins"] == '5') {
@@ -158,7 +154,6 @@ if (verifyWebhook($body, $headers)) {
         $conn->query("UPDATE `mythicaldash_users` SET `ram` = '" . mysqli_real_escape_string($conn, $newram) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
         $conn->query("UPDATE `mythicaldash_users` SET `disk` = '" . mysqli_real_escape_string($conn, $newdisk) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
         $conn->query("UPDATE `mythicaldash_users` SET `server_limit` = '" . mysqli_real_escape_string($conn, $newsv) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
-        $conn->close();
     }
 
     if ($row["coins"] == '6') {
@@ -174,7 +169,6 @@ if (verifyWebhook($body, $headers)) {
         $conn->query("UPDATE `mythicaldash_users` SET `ram` = '" . mysqli_real_escape_string($conn, $newram) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
         $conn->query("UPDATE `mythicaldash_users` SET `disk` = '" . mysqli_real_escape_string($conn, $newdisk) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
         $conn->query("UPDATE `mythicaldash_users` SET `server_limit` = '" . mysqli_real_escape_string($conn, $newsv) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
-        $conn->close();
     }
 
     if ($row["coins"] == '7') {
@@ -190,10 +184,22 @@ if (verifyWebhook($body, $headers)) {
         $conn->query("UPDATE `mythicaldash_users` SET `ram` = '" . mysqli_real_escape_string($conn, $newram) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
         $conn->query("UPDATE `mythicaldash_users` SET `disk` = '" . mysqli_real_escape_string($conn, $newdisk) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
         $conn->query("UPDATE `mythicaldash_users` SET `server_limit` = '" . mysqli_real_escape_string($conn, $newsv) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
-        $conn->close();
+    }
+
+    // Check if the user has no active plans left
+    $activePlans = $conn->query("SELECT COUNT(*) as count FROM `mythicaldash_payments` WHERE `ownerkey` = '" . mysqli_real_escape_string($conn, $user) . "' AND `status` = 'paid'");
+    $activePlansCount = $activePlans->fetch_assoc()['count'];
+
+    if ($activePlansCount == 0) {
+        // Remove 'Premium' role from the user
+        $currentRole = $session->getUserInfo("role");
+        $newRole = str_replace(',Premium', '', $currentRole);
+        $conn->query("UPDATE `mythicaldash_users` SET `role` = '" . mysqli_real_escape_string($conn, $newRole) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
     }
 
     $conn->query("DELETE FROM `mythicaldash_payments` WHERE `code` = $payment_id LIMIT 1");
+
+    $conn->close();
 
     http_response_code(200);
     echo 'Webhook processed';

--- a/view/stripe/cancel_advanced.php
+++ b/view/stripe/cancel_advanced.php
@@ -65,6 +65,18 @@ try {
     $conn->query("UPDATE `mythicaldash_users` SET `ram` = '" . mysqli_real_escape_string($conn, $newram) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
     $conn->query("UPDATE `mythicaldash_users` SET `disk` = '" . mysqli_real_escape_string($conn, $newdisk) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
     $conn->query("UPDATE `mythicaldash_users` SET `server_limit` = '" . mysqli_real_escape_string($conn, $newsv) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
+
+    // Check if the user has no active plans left
+    $activePlans = $conn->query("SELECT COUNT(*) as count FROM `mythicaldash_payments` WHERE `ownerkey` = '" . mysqli_real_escape_string($conn, $user) . "' AND `status` = 'paid'");
+    $activePlansCount = $activePlans->fetch_assoc()['count'];
+
+    if ($activePlansCount == 0) {
+        // Remove 'Premium' role from the user
+        $currentRole = $session->getUserInfo("role");
+        $newRole = str_replace(',Premium', '', $currentRole);
+        $conn->query("UPDATE `mythicaldash_users` SET `role` = '" . mysqli_real_escape_string($conn, $newRole) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
+    }
+
     $conn->close();
 
     header('Location: /dashboard?s=Succesfully%20cancelled%20your%20subscription!');

--- a/view/stripe/cancel_basic.php
+++ b/view/stripe/cancel_basic.php
@@ -65,6 +65,18 @@ try {
     $conn->query("UPDATE `mythicaldash_users` SET `ram` = '" . mysqli_real_escape_string($conn, $newram) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
     $conn->query("UPDATE `mythicaldash_users` SET `disk` = '" . mysqli_real_escape_string($conn, $newdisk) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
     $conn->query("UPDATE `mythicaldash_users` SET `server_limit` = '" . mysqli_real_escape_string($conn, $newsv) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
+
+    // Check if the user has no active plans left
+    $activePlans = $conn->query("SELECT COUNT(*) as count FROM `mythicaldash_payments` WHERE `ownerkey` = '" . mysqli_real_escape_string($conn, $user) . "' AND `status` = 'paid'");
+    $activePlansCount = $activePlans->fetch_assoc()['count'];
+
+    if ($activePlansCount == 0) {
+        // Remove 'Premium' role from the user
+        $currentRole = $session->getUserInfo("role");
+        $newRole = str_replace(',Premium', '', $currentRole);
+        $conn->query("UPDATE `mythicaldash_users` SET `role` = '" . mysqli_real_escape_string($conn, $newRole) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
+    }
+
     $conn->close();
 
     header('Location: /dashboard?s=Succesfully%20cancelled%20your%20subscription!');

--- a/view/stripe/cancel_elite.php
+++ b/view/stripe/cancel_elite.php
@@ -65,6 +65,18 @@ try {
     $conn->query("UPDATE `mythicaldash_users` SET `ram` = '" . mysqli_real_escape_string($conn, $newram) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
     $conn->query("UPDATE `mythicaldash_users` SET `disk` = '" . mysqli_real_escape_string($conn, $newdisk) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
     $conn->query("UPDATE `mythicaldash_users` SET `server_limit` = '" . mysqli_real_escape_string($conn, $newsv) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
+
+    // Check if the user has no active plans left
+    $activePlans = $conn->query("SELECT COUNT(*) as count FROM `mythicaldash_payments` WHERE `ownerkey` = '" . mysqli_real_escape_string($conn, $user) . "' AND `status` = 'paid'");
+    $activePlansCount = $activePlans->fetch_assoc()['count'];
+
+    if ($activePlansCount == 0) {
+        // Remove 'Premium' role from the user
+        $currentRole = $session->getUserInfo("role");
+        $newRole = str_replace(',Premium', '', $currentRole);
+        $conn->query("UPDATE `mythicaldash_users` SET `role` = '" . mysqli_real_escape_string($conn, $newRole) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
+    }
+
     $conn->close();
 
     header('Location: /dashboard?s=Succesfully%20cancelled%20your%20subscription!');

--- a/view/stripe/cancel_pro.php
+++ b/view/stripe/cancel_pro.php
@@ -65,6 +65,18 @@ try {
     $conn->query("UPDATE `mythicaldash_users` SET `ram` = '" . mysqli_real_escape_string($conn, $newram) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
     $conn->query("UPDATE `mythicaldash_users` SET `disk` = '" . mysqli_real_escape_string($conn, $newdisk) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
     $conn->query("UPDATE `mythicaldash_users` SET `server_limit` = '" . mysqli_real_escape_string($conn, $newsv) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
+    
+    // Check if the user has no active plans left
+    $activePlans = $conn->query("SELECT COUNT(*) as count FROM `mythicaldash_payments` WHERE `ownerkey` = '" . mysqli_real_escape_string($conn, $user) . "' AND `status` = 'paid'");
+    $activePlansCount = $activePlans->fetch_assoc()['count'];
+
+    if ($activePlansCount == 0) {
+        // Remove 'Premium' role from the user
+        $currentRole = $session->getUserInfo("role");
+        $newRole = str_replace(',Premium', '', $currentRole);
+        $conn->query("UPDATE `mythicaldash_users` SET `role` = '" . mysqli_real_escape_string($conn, $newRole) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
+    }
+
     $conn->close();
 
     header('Location: /dashboard?s=Succesfully%20cancelled%20your%20subscription!');

--- a/view/stripe/cancel_standard.php
+++ b/view/stripe/cancel_standard.php
@@ -65,6 +65,18 @@ try {
     $conn->query("UPDATE `mythicaldash_users` SET `ram` = '" . mysqli_real_escape_string($conn, $newram) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
     $conn->query("UPDATE `mythicaldash_users` SET `disk` = '" . mysqli_real_escape_string($conn, $newdisk) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
     $conn->query("UPDATE `mythicaldash_users` SET `server_limit` = '" . mysqli_real_escape_string($conn, $newsv) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
+    
+    // Check if the user has no active plans left
+    $activePlans = $conn->query("SELECT COUNT(*) as count FROM `mythicaldash_payments` WHERE `ownerkey` = '" . mysqli_real_escape_string($conn, $user) . "' AND `status` = 'paid'");
+    $activePlansCount = $activePlans->fetch_assoc()['count'];
+
+    if ($activePlansCount == 0) {
+        // Remove 'Premium' role from the user
+        $currentRole = $session->getUserInfo("role");
+        $newRole = str_replace(',Premium', '', $currentRole);
+        $conn->query("UPDATE `mythicaldash_users` SET `role` = '" . mysqli_real_escape_string($conn, $newRole) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
+    }
+    
     $conn->close();
 
     header('Location: /dashboard?s=Succesfully%20cancelled%20your%20subscription!');

--- a/view/stripe/cancel_starter.php
+++ b/view/stripe/cancel_starter.php
@@ -65,6 +65,18 @@ try {
     $conn->query("UPDATE `mythicaldash_users` SET `ram` = '" . mysqli_real_escape_string($conn, $newram) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
     $conn->query("UPDATE `mythicaldash_users` SET `disk` = '" . mysqli_real_escape_string($conn, $newdisk) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
     $conn->query("UPDATE `mythicaldash_users` SET `server_limit` = '" . mysqli_real_escape_string($conn, $newsv) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
+    
+    // Check if the user has no active plans left
+    $activePlans = $conn->query("SELECT COUNT(*) as count FROM `mythicaldash_payments` WHERE `ownerkey` = '" . mysqli_real_escape_string($conn, $user) . "' AND `status` = 'paid'");
+    $activePlansCount = $activePlans->fetch_assoc()['count'];
+
+    if ($activePlansCount == 0) {
+        // Remove 'Premium' role from the user
+        $currentRole = $session->getUserInfo("role");
+        $newRole = str_replace(',Premium', '', $currentRole);
+        $conn->query("UPDATE `mythicaldash_users` SET `role` = '" . mysqli_real_escape_string($conn, $newRole) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
+    }
+    
     $conn->close();
 
     header('Location: /dashboard?s=Succesfully%20cancelled%20your%20subscription!');

--- a/view/stripe/cancel_ultimate.php
+++ b/view/stripe/cancel_ultimate.php
@@ -65,6 +65,18 @@ try {
     $conn->query("UPDATE `mythicaldash_users` SET `ram` = '" . mysqli_real_escape_string($conn, $newram) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
     $conn->query("UPDATE `mythicaldash_users` SET `disk` = '" . mysqli_real_escape_string($conn, $newdisk) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
     $conn->query("UPDATE `mythicaldash_users` SET `server_limit` = '" . mysqli_real_escape_string($conn, $newsv) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
+    
+    // Check if the user has no active plans left
+    $activePlans = $conn->query("SELECT COUNT(*) as count FROM `mythicaldash_payments` WHERE `ownerkey` = '" . mysqli_real_escape_string($conn, $user) . "' AND `status` = 'paid'");
+    $activePlansCount = $activePlans->fetch_assoc()['count'];
+
+    if ($activePlansCount == 0) {
+        // Remove 'Premium' role from the user
+        $currentRole = $session->getUserInfo("role");
+        $newRole = str_replace(',Premium', '', $currentRole);
+        $conn->query("UPDATE `mythicaldash_users` SET `role` = '" . mysqli_real_escape_string($conn, $newRole) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $user) . "';");
+    }
+    
     $conn->close();
 
     header('Location: /dashboard?s=Succesfully%20cancelled%20your%20subscription!');

--- a/view/stripe/get_advanced.php
+++ b/view/stripe/get_advanced.php
@@ -33,6 +33,14 @@ try {
             $conn->query("UPDATE `mythicaldash_users` SET `ram` = '" . mysqli_real_escape_string($conn, $newram) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $_COOKIE['token']) . "';");
             $conn->query("UPDATE `mythicaldash_users` SET `disk` = '" . mysqli_real_escape_string($conn, $newdisk) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $_COOKIE['token']) . "';");
             $conn->query("UPDATE `mythicaldash_users` SET `server_limit` = '" . mysqli_real_escape_string($conn, $newsv) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $_COOKIE['token']) . "';");
+            
+            // Assign 'Premium' role to the user
+            $currentRole = $session->getUserInfo("role");
+            if (strpos($currentRole, 'Premium') === false) {
+                $newRole = $currentRole . ',Premium';
+                $conn->query("UPDATE `mythicaldash_users` SET `role` = '" . mysqli_real_escape_string($conn, $newRole) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $_COOKIE['token']) . "';");
+            }
+
             $conn->close();
             http_response_code(201);
             die();

--- a/view/stripe/get_basic.php
+++ b/view/stripe/get_basic.php
@@ -33,6 +33,14 @@ try {
             $conn->query("UPDATE `mythicaldash_users` SET `ram` = '" . mysqli_real_escape_string($conn, $newram) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $_COOKIE['token']) . "';");
             $conn->query("UPDATE `mythicaldash_users` SET `disk` = '" . mysqli_real_escape_string($conn, $newdisk) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $_COOKIE['token']) . "';");
             $conn->query("UPDATE `mythicaldash_users` SET `server_limit` = '" . mysqli_real_escape_string($conn, $newsv) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $_COOKIE['token']) . "';");
+            
+            // Assign 'Premium' role to the user
+            $currentRole = $session->getUserInfo("role");
+            if (strpos($currentRole, 'Premium') === false) {
+                $newRole = $currentRole . ',Premium';
+                $conn->query("UPDATE `mythicaldash_users` SET `role` = '" . mysqli_real_escape_string($conn, $newRole) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $_COOKIE['token']) . "';");
+            }
+
             $conn->close();
             http_response_code(201);
             die();

--- a/view/stripe/get_elite.php
+++ b/view/stripe/get_elite.php
@@ -33,6 +33,14 @@ try {
             $conn->query("UPDATE `mythicaldash_users` SET `ram` = '" . mysqli_real_escape_string($conn, $newram) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $_COOKIE['token']) . "';");
             $conn->query("UPDATE `mythicaldash_users` SET `disk` = '" . mysqli_real_escape_string($conn, $newdisk) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $_COOKIE['token']) . "';");
             $conn->query("UPDATE `mythicaldash_users` SET `server_limit` = '" . mysqli_real_escape_string($conn, $newsv) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $_COOKIE['token']) . "';");
+            
+            // Assign 'Premium' role to the user
+            $currentRole = $session->getUserInfo("role");
+            if (strpos($currentRole, 'Premium') === false) {
+                $newRole = $currentRole . ',Premium';
+                $conn->query("UPDATE `mythicaldash_users` SET `role` = '" . mysqli_real_escape_string($conn, $newRole) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $_COOKIE['token']) . "';");
+            }
+
             $conn->close();
             http_response_code(201);
             die();

--- a/view/stripe/get_pro.php
+++ b/view/stripe/get_pro.php
@@ -33,6 +33,14 @@ try {
             $conn->query("UPDATE `mythicaldash_users` SET `ram` = '" . mysqli_real_escape_string($conn, $newram) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $_COOKIE['token']) . "';");
             $conn->query("UPDATE `mythicaldash_users` SET `disk` = '" . mysqli_real_escape_string($conn, $newdisk) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $_COOKIE['token']) . "';");
             $conn->query("UPDATE `mythicaldash_users` SET `server_limit` = '" . mysqli_real_escape_string($conn, $newsv) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $_COOKIE['token']) . "';");
+            
+            // Assign 'Premium' role to the user
+            $currentRole = $session->getUserInfo("role");
+            if (strpos($currentRole, 'Premium') === false) {
+                $newRole = $currentRole . ',Premium';
+                $conn->query("UPDATE `mythicaldash_users` SET `role` = '" . mysqli_real_escape_string($conn, $newRole) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $_COOKIE['token']) . "';");
+            }
+
             $conn->close();
             http_response_code(201);
             die();

--- a/view/stripe/get_standard.php
+++ b/view/stripe/get_standard.php
@@ -33,6 +33,14 @@ try {
             $conn->query("UPDATE `mythicaldash_users` SET `ram` = '" . mysqli_real_escape_string($conn, $newram) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $_COOKIE['token']) . "';");
             $conn->query("UPDATE `mythicaldash_users` SET `disk` = '" . mysqli_real_escape_string($conn, $newdisk) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $_COOKIE['token']) . "';");
             $conn->query("UPDATE `mythicaldash_users` SET `server_limit` = '" . mysqli_real_escape_string($conn, $newsv) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $_COOKIE['token']) . "';");
+            
+            // Assign 'Premium' role to the user
+            $currentRole = $session->getUserInfo("role");
+            if (strpos($currentRole, 'Premium') === false) {
+                $newRole = $currentRole . ',Premium';
+                $conn->query("UPDATE `mythicaldash_users` SET `role` = '" . mysqli_real_escape_string($conn, $newRole) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $_COOKIE['token']) . "';");
+            }
+
             $conn->close();
             http_response_code(201);
             die();

--- a/view/stripe/get_starter.php
+++ b/view/stripe/get_starter.php
@@ -33,6 +33,14 @@ try {
             $conn->query("UPDATE `mythicaldash_users` SET `ram` = '" . mysqli_real_escape_string($conn, $newram) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $_COOKIE['token']) . "';");
             $conn->query("UPDATE `mythicaldash_users` SET `disk` = '" . mysqli_real_escape_string($conn, $newdisk) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $_COOKIE['token']) . "';");
             $conn->query("UPDATE `mythicaldash_users` SET `server_limit` = '" . mysqli_real_escape_string($conn, $newsv) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $_COOKIE['token']) . "';");
+            
+            // Assign 'Premium' role to the user
+            $currentRole = $session->getUserInfo("role");
+            if (strpos($currentRole, 'Premium') === false) {
+                $newRole = $currentRole . ',Premium';
+                $conn->query("UPDATE `mythicaldash_users` SET `role` = '" . mysqli_real_escape_string($conn, $newRole) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $_COOKIE['token']) . "';");
+            }
+
             $conn->close();
             http_response_code(201);
             die();

--- a/view/stripe/get_ultimate.php
+++ b/view/stripe/get_ultimate.php
@@ -33,6 +33,14 @@ try {
             $conn->query("UPDATE `mythicaldash_users` SET `ram` = '" . mysqli_real_escape_string($conn, $newram) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $_COOKIE['token']) . "';");
             $conn->query("UPDATE `mythicaldash_users` SET `disk` = '" . mysqli_real_escape_string($conn, $newdisk) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $_COOKIE['token']) . "';");
             $conn->query("UPDATE `mythicaldash_users` SET `server_limit` = '" . mysqli_real_escape_string($conn, $newsv) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $_COOKIE['token']) . "';");
+            
+            // Assign 'Premium' role to the user
+            $currentRole = $session->getUserInfo("role");
+            if (strpos($currentRole, 'Premium') === false) {
+                $newRole = $currentRole . ',Premium';
+                $conn->query("UPDATE `mythicaldash_users` SET `role` = '" . mysqli_real_escape_string($conn, $newRole) . "' WHERE `mythicaldash_users`.`api_key` = '" . mysqli_real_escape_string($conn, $_COOKIE['token']) . "';");
+            }
+
             $conn->close();
             http_response_code(201);
             die();


### PR DESCRIPTION
Add functionality to assign and remove 'Premium' role based on plan purchases and cancellations.

* In `view/stripe/get_advanced.php`, `view/stripe/get_basic.php`, `view/stripe/get_elite.php`, `view/stripe/get_pro.php`, `view/stripe/get_standard.php`, `view/stripe/get_starter.php`, and `view/stripe/get_ultimate.php`, add code to assign 'Premium' role to the user after successful payment.
* In `view/stripe/cancel_advanced.php`, `view/stripe/cancel_basic.php`, `view/stripe/cancel_elite.php`, `view/stripe/cancel_pro.php`, `view/stripe/cancel_standard.php`, `view/stripe/cancel_starter.php`, and `view/stripe/cancel_ultimate.php`, add code to check if the user has no active plans left and remove 'Premium' role from the user if no active plans are found.
* In `api/store/removesubscription.php`, add code to check if the user has no active plans left and remove 'Premium' role from the user if no active plans are found.

