### PR TITLE
Add premium egg restriction

### DIFF
--- a/app/EggManagerConfig.php
+++ b/app/EggManagerConfig.php
@@ -18,6 +18,10 @@ class EggManagerConfig
         if ($row = $result->fetch_assoc()) {
             return $row["setting_value"];
         }
+        // Default value for premium_only setting
+        if ($settingName === 'premium_only') {
+            return 'false';
+        }
         return null;
     }
 
@@ -49,6 +53,21 @@ class EggManagerConfig
         $stmt = $conn->prepare($sql);
         $stmt->bind_param("ss", $settingName, $settingValue);
         return $stmt->execute();
+    }
+
+    public static function isPremiumOnly($eggId)
+    {
+        $connect = new Connect();
+        $conn = $connect->connectToDatabase();
+        $sql = "SELECT premium_only FROM mythicaldash_eggs WHERE id = ?";
+        $stmt = $conn->prepare($sql);
+        $stmt->bind_param("i", $eggId);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        if ($row = $result->fetch_assoc()) {
+            return $row["premium_only"];
+        }
+        return false;
     }
 }
 ?>

--- a/migrate/85.sql
+++ b/migrate/85.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `mythicaldash_eggs`
+ADD COLUMN `premium_only` BOOLEAN NOT NULL DEFAULT false;

--- a/routes/admin/eggs.php
+++ b/routes/admin/eggs.php
@@ -28,5 +28,8 @@ $router->add("/admin/eggs/config/delete", function () {
     require("../include/main.php");
     require("../view/admin/eggs/manager_delete.php");
 });
-    
-?>
+
+$router->add("/admin/eggs/config/premium", function () {
+    require("../include/main.php");
+    require("../view/admin/eggs/config_premium.php");
+});

--- a/view/admin/eggs/create.php
+++ b/view/admin/eggs/create.php
@@ -6,6 +6,7 @@ if (isset($_GET['create_egg'])) {
     $category = mysqli_real_escape_string($conn, $_GET['category']);
     $nest_id = mysqli_real_escape_string($conn, $_GET['nest_id']);
     $nest_egg_id = mysqli_real_escape_string($conn, $_GET['nest_egg_id']);
+    $premium_only = isset($_GET['premium_only']) ? 'true' : 'false'; // P7c40
     if ($name == "" || $category == "" || $nest_id == "" || $nest_egg_id == "" ) {
         header('location: /admin/eggs/list?e=Please fill in all information.');
         die();
@@ -18,7 +19,7 @@ if (isset($_GET['create_egg'])) {
             die();
 
         } else {
-            $conn->query("INSERT INTO `mythicaldash_eggs` (`name`, `category`, `egg`, `nest`) VALUES ('" . $name . "', '" . $category . "', '" . $nest_egg_id . "', '" . $nest_id . "');");
+            $conn->query("INSERT INTO `mythicaldash_eggs` (`name`, `category`, `egg`, `nest`, `premium_only`) VALUES ('" . $name . "', '" . $category . "', '" . $nest_egg_id . "', '" . $nest_id . "', '" . $premium_only . "');"); // Pf3e0
             header('location: /admin/eggs/list?s=Done we added a new egg');
             $conn->close();
             die();

--- a/view/admin/eggs/main.php
+++ b/view/admin/eggs/main.php
@@ -77,6 +77,7 @@ $totalPages = ceil($totalEggs / $eggsPerPage);
                                             <th>Category</th>
                                             <th>Egg id</th>
                                             <th>Nest id</th>
+                                            <th>Premium Only</th>
                                             <th>Created</th>
                                             <th>Action</th>
                                         </tr>
@@ -90,6 +91,7 @@ $totalPages = ceil($totalEggs / $eggsPerPage);
                                                 echo "<td>" . $row['category'] . "</td>";
                                                 echo "<td>" . $row['egg'] . "</td>";
                                                 echo "<td>" . $row['nest'] . "</td>";
+                                                echo "<td>" . ($row['premium_only'] === 'true' ? 'Yes' : 'No') . "</td>";
                                                 echo "<td><code>" . $row['date'] . "</code></td>";
                                                 echo "<td><!--<a href=\"/admin/eggs/edit?id=" . $row['id'] . "\" class=\"btn btn-primary\">Edit</a>-->&nbsp;<a href=\"/admin/eggs/delete?id=" . $row['id'] . "\" class=\"btn btn-danger\">Delete</a></td>";
                                                 echo "</tr>";
@@ -146,6 +148,10 @@ $totalPages = ceil($totalEggs / $eggsPerPage);
                                         <label class="form-label" for="nest_egg_id">Egg ID</label>
                                         <input type="number" id="nest_egg_id" name="nest_egg_id" class="form-control"
                                             placeholder="" required value="3" />
+                                    </div>
+                                    <div class="col-12">
+                                        <label class="form-label" for="premium_only">Premium Only</label>
+                                        <input type="checkbox" id="premium_only" name="premium_only" class="form-check-input" />
                                     </div>
                                     <div class="col-12 text-center">
                                         <button type="submit" name="create_egg" value="create_egg"

--- a/view/admin/eggs/manager_create.php
+++ b/view/admin/eggs/manager_create.php
@@ -6,6 +6,7 @@ include(__DIR__ . '/../../requirements/admin.php');
 if (isset($_GET['create_egg'])) {
     $name = mysqli_real_escape_string($conn, $_GET['name']);
     $value = mysqli_real_escape_string($conn, $_GET['value']);
+    $premium_only = isset($_GET['premium_only']) ? 'true' : 'false';
     if ($name == "" || $value == "") {
         header('location: /admin/eggs/config?e=Please fill in all information.');
         die();

--- a/view/admin/eggs/manager_list.php
+++ b/view/admin/eggs/manager_list.php
@@ -75,6 +75,7 @@ $totalPages = ceil($totalEggs / $eggsPerPage);
                                             <th>ID</th>
                                             <th>Name</th>
                                             <th>Value</th>
+                                            <th>Premium Only</th>
                                             <th>Action</th>
                                         </tr>
                                     </thead>
@@ -86,6 +87,7 @@ $totalPages = ceil($totalEggs / $eggsPerPage);
                                                 echo "<td>#" . $row['id'] . "</td>";
                                                 echo "<td>" . $row['setting_name'] . "</td>";
                                                 echo "<td>" . $row['setting_value'] . "</td>";
+                                                echo "<td>" . ($row['premium_only'] === 'true' ? 'Yes' : 'No') . "</td>";
                                                 echo "<td><!--<a href=\"/admin/eggs/edit?id=" . $row['id'] . "\" class=\"btn btn-primary\">Edit</a>-->&nbsp;<a href=\"/admin/eggs/config/delete?name=" . $row['setting_name'] . "\" class=\"btn btn-danger\">Delete</a></td>";
                                                 echo "</tr>";
                                             }
@@ -131,6 +133,10 @@ $totalPages = ceil($totalEggs / $eggsPerPage);
                                         <label class="form-label" for="value">Value</label>
                                         <input type="text" id="value" name="value" class="form-control"
                                             placeholder="Minecraft" required />
+                                    </div>
+                                    <div class="col-12">
+                                        <label class="form-label" for="premium_only">Premium Only</label>
+                                        <input type="checkbox" id="premium_only" name="premium_only" class="form-check-input" />
                                     </div>
                                     <div class="col-12 text-center">
                                         <button type="submit" name="create_egg" value="create_egg"

--- a/view/server/create.php
+++ b/view/server/create.php
@@ -1,6 +1,7 @@
 <?php
 use MythicalDash\ErrorHandler;
 use MythicalDash\SettingsManager;
+use MythicalDash\EggManagerConfig;
 
 include (__DIR__ . '/../requirements/page.php');
 $csrf = new MythicalSystems\Utils\CSRFHandler;
@@ -174,6 +175,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         die ();
       }
       $egg = $doeseggexist->fetch_object();
+      if (EggManagerConfig::isPremiumOnly($s_egg) && !in_array($userdb->role, ['User,Premium', 'Support', 'Administrator'])) {
+        header('location: /server/create?e=This egg is limited to Premium users, Support, and Administrators only.');
+        $conn->close();
+        die ();
+      }
       $conn->query("INSERT INTO mythicaldash_servers_queue (`name`, `ram`, `disk`, `cpu`, `xtra_ports`, `databases`, `backuplimit`, `location`, `ownerid`, `type`, `egg`, `puid`
       ) VALUES (
         '" . mysqli_real_escape_string($conn, $s_name) . "',


### PR DESCRIPTION
Add functionality to limit eggs to Premium users, Support, and Administrators.

* **Database Migration**
  - Add a new column `premium_only` to the `mythicaldash_eggs` table as a boolean.

* **EggManagerConfig.php**
  - Add a new method `isPremiumOnly` to check if a specific egg is limited to Premium users, Support, and Administrators.
  - Modify the `getConfig` method to include a default value for `premium_only` setting.

* **Admin Routes**
  - Add a new route `/admin/eggs/config/premium` to handle setting eggs as Premium, Support, and Administrators only.

* **Admin Views**
  - Add a new field in the form to set the egg as Premium, Support, and Administrators only in `create.php`.
  - Modify the logic to include the `premium_only` field when creating a new egg in `create.php`.
  - Display a column indicating whether an egg is Premium, Support, and Administrators only in `main.php`.
  - Add a checkbox to the egg adding menu to make it premium only in `main.php`.
  - Add logic to handle the `premium_only` setting when creating a new egg configuration in `manager_create.php`.
  - Display the `premium_only` setting in the list of egg configurations in `manager_list.php`.
  - Add a checkbox in the form to make it premium only in `manager_list.php`.

* **Server Creation**
  - Add logic to check if an egg is premium only when creating a server in `create.php`.
  - Only allow creation of a server with a premium egg for the following roles: User, Premium, Support, Administrator in `create.php`.

